### PR TITLE
xserver: update to 1.19

### DIFF
--- a/recipes-graphics/xorg-xserver/libinput_%.bbappend
+++ b/recipes-graphics/xorg-xserver/libinput_%.bbappend
@@ -1,0 +1,4 @@
+PV = "1.6.1"
+
+SRC_URI[md5sum] = "7e282344f8ed7ec5cf87ca9fc22674fb"
+SRC_URI[sha256sum] = "9d816f13eee63bcca0e9c3bb652c52ab55f39be4d1b90b54e4bfd1dc92ef55a8"

--- a/recipes-graphics/xorg-xserver/libxfont2_2.0.1.bb
+++ b/recipes-graphics/xorg-xserver/libxfont2_2.0.1.bb
@@ -1,0 +1,22 @@
+SUMMARY = "XFont2: X Font rasterisation library"
+
+DESCRIPTION = "libXfont2 provides various services for X servers, most \
+notably font selection and rasterisation (through external libraries \
+such as freetype)."
+
+require recipes-graphics/xorg-lib/xorg-lib-common.inc
+
+LICENSE = "MIT & MIT-style & BSD"
+LIC_FILES_CHKSUM = "file://COPYING;md5=a46c8040f2f737bcd0c435feb2ab1c2c"
+
+DEPENDS += "freetype xtrans fontsproto libfontenc zlib"
+
+XORG_PN = "libXfont2"
+
+BBCLASSEXTEND = "native"
+
+SRC_URI[md5sum] = "0d9f6dd9c23bf4bcbfb00504b566baf5"
+SRC_URI[sha256sum] = "e9fbbb475ddd171b3a6a54b989cbade1f6f874fc35d505ebc5be426bc6e4db7e"
+
+PACKAGECONFIG ??= "${@bb.utils.contains('DISTRO_FEATURES', 'ipv6', 'ipv6', '', d)}"
+PACKAGECONFIG[ipv6] = "--enable-ipv6,--disable-ipv6,"

--- a/recipes-graphics/xorg-xserver/xf86-input-libinput_%.bbappend
+++ b/recipes-graphics/xorg-xserver/xf86-input-libinput_%.bbappend
@@ -1,0 +1,4 @@
+PV = "0.25.1"
+
+SRC_URI[md5sum] = "14003139614b25cc76c9a4cad059df89"
+SRC_URI[sha256sum] = "489f7d591c9ef08463d4966e61f7c6ea433f5fcbb9f5370fb621da639a84c7e0"

--- a/recipes-graphics/xorg-xserver/xproto_%.bbappend
+++ b/recipes-graphics/xorg-xserver/xproto_%.bbappend
@@ -1,0 +1,5 @@
+PV = "7.0.31"
+
+SRC_URI[md5sum] = "16791f7ca8c51a20608af11702e51083"
+SRC_URI[sha256sum] = "c6f9747da0bd3a95f86b17fb8dd5e717c8f3ab7f0ece3ba1b247899ec1ef7747"
+

--- a/recipes-graphics/xorg-xserver/xserver-xorg_rk.bb
+++ b/recipes-graphics/xorg-xserver/xserver-xorg_rk.bb
@@ -1,10 +1,10 @@
 require recipes-graphics/xorg-xserver/xserver-xorg.inc
 
-SRCBRANCH ?= "rockchip-1.18"
+SRCBRANCH ?= "rockchip-1.19"
 SRC_URI = "git://github.com/rockchip-linux/xserver.git;branch=${SRCBRANCH}"
 SRC_URI += "file://macro_tweak.patch"
 SRC_URI += "file://musl-arm-inb-outb.patch"
-SRCREV = "6f770de04d50422af48f83e17de7197ed0a76fdb"
+SRCREV = "fa67c936a8712cbcb7b33bc66cfd8e206cc21546"
 S = "${WORKDIR}/git"
 
 PACKAGECONFIG_append = " glamor dri3 unwind xshmfence"

--- a/recipes-graphics/xorg-xserver/xserver-xorg_rk.bb
+++ b/recipes-graphics/xorg-xserver/xserver-xorg_rk.bb
@@ -1,5 +1,7 @@
 require recipes-graphics/xorg-xserver/xserver-xorg.inc
 
+DEPENDS += " libxfont2"
+
 SRCBRANCH ?= "rockchip-1.19"
 SRC_URI = "git://github.com/rockchip-linux/xserver.git;branch=${SRCBRANCH}"
 SRC_URI += "file://macro_tweak.patch"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad.inc
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad.inc
@@ -20,7 +20,7 @@ PACKAGECONFIG ??= " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'bluez', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'directfb', 'directfb', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'gtk', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wayland egl gtk', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'weston egl', '', d)} \
     bz2 curl dash dtls hls neon rsvg sbc smoothstreaming sndfile uvch264 webp \
 "
 


### PR DESCRIPTION
We use 1.19 xserver in Debian.
I'd like yocto use same xserver with debian.