### PR TITLE
add extra 10MiB to keep GPT backup table safe

### DIFF
--- a/classes/rockchip-gpt-img.bbclass
+++ b/classes/rockchip-gpt-img.bbclass
@@ -90,7 +90,8 @@ create_rk_image () {
 
 	GPTIMG_MIN_SIZE=$(expr $IMG_ROOTFS_SIZE + \( ${LOADER1_SIZE} + ${RESERVED1_SIZE} + ${RESERVED2_SIZE} + ${LOADER2_SIZE} + ${ATF_SIZE} + ${BOOT_SIZE} + 35 \) \* 512 )
 
-	GPT_IMAGE_SIZE=$(expr $GPTIMG_MIN_SIZE \/ 1024 \/ 1024 + 1)
+	# add extra 10 MiB for safe area to keep out GPT backup table
+	GPT_IMAGE_SIZE=$(expr $GPTIMG_MIN_SIZE \/ 1024 \/ 1024 + 10)
 
 	# Initialize sdcard image file
 	dd if=/dev/zero of=${GPTIMG} bs=1M count=0 seek=$GPT_IMAGE_SIZE


### PR DESCRIPTION
last commit I added only 1 MiB, but it seems due to division error, it is not large enough when writing rootfs to the image the backup GPT table is corrupted. So I added extra 10 MiB to keep it safe. 