### PR TITLE
qtbase: set PACKAGECONFIG_GL only if OpenGL is enabled in distro

### DIFF
--- a/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
+++ b/dynamic-layers/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
@@ -1,7 +1,7 @@
 # Copyright (C) 2017 Fuzhou Rockchip Electronics Co., Ltd
 # Released under the MIT license (see COPYING.MIT for the terms)
 
-PACKAGECONFIG_GL   = "gles2"
+PACKAGECONFIG_GL = "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'gles2', '', d)}"
 PACKAGECONFIG_FONTS	= "fontconfig"
 
 PACKAGECONFIG_APPEND = " \


### PR DESCRIPTION
With OpenGL disabled, this layer shouldn't force qtbase to be built
with GLES2 support.