### PR TITLE
u-boot-mkimage: override LIC_FILES_CHKSUM as well

### DIFF
--- a/recipes-bsp/u-boot/u-boot-mkimage_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-mkimage_%.bbappend
@@ -1,5 +1,6 @@
 # This revision corresponds to the tag "v2017.01"
 # We use the revision in order to avoid having to fetch it from the
 # repo during parse
+LIC_FILES_CHKSUM = "file://Licenses/README;md5=a2c678cfd4a4d97135585cad908541c6"
 SRC_URI = "git://github.com/rockchip-linux/u-boot.git;nobranch=1;"
 SRCREV = "5ecf0ee53bba61db0a04402e4bb83e991658ffd0"


### PR DESCRIPTION
The git commit we're seeking in the *.bboverride has a different
license checksum than the one from oe-core.