### PR TITLE
rockchip-gpt-img: use `${KERNEL_DEVICETREE}` to locate `*.dtb` file

### DIFF
--- a/classes/rockchip-gpt-img.bbclass
+++ b/classes/rockchip-gpt-img.bbclass
@@ -148,17 +148,8 @@ EOF
 	mkfs.vfat -n "boot" -S 512 -C ${WORKDIR}/${BOOT_IMG} $BOOT_BLOCKS
 	mcopy -i ${WORKDIR}/${BOOT_IMG} -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-${MACHINE}.bin ::${KERNEL_IMAGETYPE}
 
-	DTS_FILE=""
-	DTBPATTERN="${KERNEL_IMAGETYPE}((-\w+)+\.dtb)"
-	for DFILES in ${DEPLOY_DIR_IMAGE}/*; do
-		DFILES=${DFILES##*/}
-		if echo "${DFILES}" | grep -P $DTBPATTERN ; then
-			[ -n "${DTS_FILE}" ] && bberror "Found multiple DTB under deploy dir, Please delete the unnecessary one."
-			DTS_FILE=${DFILES#*${KERNEL_IMAGETYPE}-}
-		fi
-	done
-
-	mcopy -i ${WORKDIR}/${BOOT_IMG} -s ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-${DTS_FILE} ::${DTS_FILE}
+	DTS_FILE="$(basename "${KERNEL_DEVICETREE}")"
+	mcopy -i ${WORKDIR}/${BOOT_IMG} -s ${DEPLOY_DIR_IMAGE}/${DTS_FILE} ::${DTS_FILE}
 
 	# Create extlinux config file
 	cat >${WORKDIR}/extlinux.conf <<EOF


### PR DESCRIPTION
Since oe-core commit
https://github.com/openembedded/openembedded-core/commit/1860d9d3c62e2e94cd68a809385873ffd8270b6d
meta-rockchip's `create_rk_image()` function failed because it could
not locate the DeviceTree binary.  That oe-core commit disabled the
symlinks which were expected to be present.

However those symlinks were not necessary; it it a lot easier to just
use the `${KERNEL_DEVICETREE}` variable which contains the file name
within the `deploy` directory; however, we need to strip off the
directory name.  The path name in `${KERNEL_DEVICETREE}` is relative
to the `deploy/images` directory, however there is no BitBake variable
specifying this directory; there is `${DEPLOY_DIR}` which points to
`deploy`, and `${DEPLOY_DIR_IMAGE}` points to
`deploy/images/${MACHINE}`.