### PR TITLE
rockchip-mali_rk.bb: set SRC_URI url to the working one

### DIFF
--- a/recipes-graphics/libgles/rockchip-mali_rk.bb
+++ b/recipes-graphics/libgles/rockchip-mali_rk.bb
@@ -65,7 +65,7 @@ python __anonymous() {
 }
 
 S = "${WORKDIR}/"
-SRC_URI = "https://github.com/rockchip-linux/libmali/raw/rockchip/lib/${MALI_TUNE}/${MALI_NAME}"
+SRC_URI = "https://github.com/rockchip-linux/libmali/raw/29mirror/lib/${MALI_TUNE}/${MALI_NAME}"
 
 INSANE_SKIP_${PN} = "already-stripped ldflags dev-so"
 


### PR DESCRIPTION
I faced following build error:

```
ERROR: rockchip-mali-rk-r0 do_fetch: Fetcher failure for URL:
'https://github.com/rockchip-linux/libmali/raw/rockchip/lib/aarch64-linux-gnu/libmali-midgard-t86x-r14p0-wayland.so'.
Unable to fetch URL from any source.
ERROR: rockchip-mali-rk-r0 do_fetch: Function failed: base_do_fetch
```

I am not sure how it works and how stable this `29mirror` will be. But now I can proceed with the build.
With the default code I could not.

Signed-off-by: Maciej Pijanowski <maciej.pijanowski@3mdeb.com>