### PR TITLE
New recipe u-boot-fw-utils-rockchip

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fw-utils-rockchip_20171218.bb
+++ b/recipes-bsp/u-boot/u-boot-fw-utils-rockchip_20171218.bb
@@ -1,0 +1,37 @@
+require recipes-bsp/u-boot/u-boot-rockchip.inc
+
+SUMMARY = "U-Boot bootloader fw_printenv/setenv utilities"
+DEPENDS = "mtd-utils"
+
+INSANE_SKIP_${PN} = "already-stripped"
+EXTRA_OEMAKE_class-target = 'CROSS_COMPILE=${TARGET_PREFIX} CC="${CC} ${CFLAGS} ${LDFLAGS}" HOSTCC="${BUILD_CC} ${BUILD_CFLAGS} ${BUILD_LDFLAGS}" V=1'
+EXTRA_OEMAKE_class-cross = 'ARCH=${TARGET_ARCH} CC="${CC} ${CFLAGS} ${LDFLAGS}" V=1'
+
+S = "${WORKDIR}/git"
+
+inherit uboot-config
+
+do_compile () {
+	oe_runmake ${UBOOT_MACHINE}
+	oe_runmake tools-only
+	oe_runmake envtools
+}
+
+do_install () {
+	install -d ${D}${base_sbindir}
+	install -d ${D}${sysconfdir}
+	install -m 755 ${S}/tools/env/fw_printenv ${D}${base_sbindir}/fw_printenv
+	install -m 755 ${S}/tools/env/fw_printenv ${D}${base_sbindir}/fw_setenv
+	install -m 0644 ${S}/tools/env/fw_env.config ${D}${sysconfdir}/fw_env.config
+}
+
+do_install_class-cross () {
+	install -d ${D}${bindir_cross}
+	install -m 755 ${S}/tools/env/fw_printenv ${D}${bindir_cross}/fw_printenv
+	install -m 755 ${S}/tools/env/fw_printenv ${D}${bindir_cross}/fw_setenv
+}
+
+SYSROOT_DIRS_append_class-cross = " ${bindir_cross}"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+BBCLASSEXTEND = "cross"

--- a/recipes-bsp/u-boot/u-boot-rockchip.inc
+++ b/recipes-bsp/u-boot/u-boot-rockchip.inc
@@ -2,8 +2,6 @@
 # Copyright (C) 2017 Trevor Woerner <twoerner@gmail.com>
 # Released under the MIT license (see COPYING.MIT for the terms)
 
-require recipes-bsp/u-boot/u-boot.inc
-
 DESCRIPTION = "Rockchip next-dev U-Boot"
 LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=a2c678cfd4a4d97135585cad908541c6"

--- a/recipes-bsp/u-boot/u-boot-rockchip_20171218.bb
+++ b/recipes-bsp/u-boot/u-boot-rockchip_20171218.bb
@@ -1,7 +1,8 @@
 # Copyright (C) 2017 Fuzhou Rockchip Electronics Co., Ltd
 # Released under the MIT license (see COPYING.MIT for the terms)
 
-include u-boot-rockchip.inc
+require u-boot-rockchip.inc
+require recipes-bsp/u-boot/u-boot.inc
 
 TAG = "release-${PV}"
 SRC_URI = " \

--- a/recipes-bsp/u-boot/u-boot-rockchip_git.bb
+++ b/recipes-bsp/u-boot/u-boot-rockchip_git.bb
@@ -3,7 +3,8 @@
 
 DEFAULT_PREFERENCE = "-1"
 
-include u-boot-rockchip.inc
+require u-boot-rockchip.inc
+require recipes-bsp/u-boot/u-boot.inc
 
 SRC_URI = " \
 	git://github.com/rockchip-linux/u-boot.git;branch=release; \


### PR DESCRIPTION
Standard poky u-boot recipe allows building u-boot-fw-utils package. This series borrows the logic from poky so we can use a single u-boot code base.