### PR TITLE
README: remove confusing instructions

### DIFF
--- a/README
+++ b/README
@@ -56,21 +56,6 @@ This layer depends on:
   Tag: 1.9_M2
 
 
-Contributing
-============
-
-Please submit any patches against this BSP to the Yocto Project mailing list:
-yocto@yoctoproject.org and cc: the following maintainers:
-
-Maintainer: Romain Perier <romain.perier@gmail.com>
-Maintainer: Trevor Woerner <twoerner@gmail.com>
-
-When sending patches please take a look at the contribution guide available
-here: https://wiki.yoctoproject.org/wiki/Contribution_Guidelines
-
-Please also send your patches by using git send-email and prefix your subject
-by "[meta-rockchip]".
-
 Table of Contents
 =================
 


### PR DESCRIPTION
Unfortunately, some people have found this information in the README and get
confused regarding how to contribute to this specific layer
(https://github.com/rockchip-linux/meta-rockchip). These instructions are a
left-over from when our layer was forked to create this layer and are not
valid.

We are not the maintainers of https://github.com/rockchip-linux/meta-rockchip.
Please don't sent patches for this layer to us.

Signed-off-by: Trevor Woerner <twoerner@gmail.com>