### PR TITLE
Prevent RK_LICENSE_PATH to invalidate sstate

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -21,6 +21,8 @@ BBFILE_PRIORITY_rockchip = "9"
 # Additional license directories.
 RK_BINARY_LICENSE = "${LAYERDIR}/files/custom-licenses/LICENSE.rockchip"
 LICENSE_PATH += "${LAYERDIR}/files/custom-licenses"
+# Avoid cache invalidation when $LAYER changes (build in different location)
+BB_HASHBASE_WHITELIST_append = " RK_BINARY_LICENSE"
 
 LAYERDEPENDS_rockchip = "core"
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -19,9 +19,8 @@ BBFILE_PATTERN_rockchip := "^${LAYERDIR}/"
 BBFILE_PRIORITY_rockchip = "9"
 
 # Additional license directories.
-RK_LICENSE_PATH = "${LAYERDIR}/files/custom-licenses"
-RK_BINARY_LICENSE = "${RK_LICENSE_PATH}/LICENSE.rockchip"
-LICENSE_PATH += "${RK_LICENSE_PATH}"
+RK_BINARY_LICENSE = "${LAYERDIR}/files/custom-licenses/LICENSE.rockchip"
+LICENSE_PATH += "${LAYERDIR}/files/custom-licenses"
 
 LAYERDEPENDS_rockchip = "core"
 


### PR DESCRIPTION
When building in a different dir, the shared-state cache fails to do
its job for several recipes, including linux-firmware.  Investigation
leads to the following.  This should arguably be warned for by bitbake,
see https://bugzilla.yoctoproject.org/show_bug.cgi?id=13968

    $ bitbake-diffsigs <DIR1>/build/tmp/stamps/all-shadow-linux/linux-firmware/1_20200122-r0.do_package.sigdata.9a9954a8c21b69ff100b5cb0e779a1da66f1bb957aaf07e3739ba64b1d3c24e9 <DIR2>/build/tmp/stamps/all-shadow-linux/linux-firmware/1_20200122-r0.do_package.sigdata.17e01400cf66db23f12bf99200820509861fe4713e97fae49c45dd27cc4cf1ab
    NOTE: Starting bitbake server...
    basehash changed from 0624972d5fbfa8598b62a83a5303ea534752643e6754281b620a0fef4d979d54 to 6d32b04939c4870c8b4ecc9e2696f05b9ca49f0a89cbc61ffb676a911855fe7b
    Variable RK_LICENSE_PATH value changed from '<DIR1>/poky/../meta-rockchip/files/custom-licenses' to '<DIR2>/poky/../meta-rockchip/files/custom-licenses'