### PR TITLE
u-boot: use .config instead of UBOOT_MACHINE defconfig

### DIFF
--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -57,7 +57,7 @@ do_compile_append() {
 		make.sh
 
 	# Pack rockchip loader images
-	./make.sh ${UBOOT_MACHINE%_defconfig}
+	./make.sh
 
 	ln -sf *_loader*.bin "${RK_LOADER_BIN}"
 

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -36,14 +36,6 @@ do_configure_prepend() {
 	for s in `grep -rIl python ${S}`; do
 		sed -i -e '1s|^#!.*python[23]*|#!/usr/bin/env nativepython|' $s
 	done
-
-	# Copy prebuilt images
-	if [ -e "${S}/${UBOOT_BINARY}" ]; then
-		bbnote "${PN}: Found prebuilt images."
-		mv ${S}/*.bin ${S}/*.img ${B}/
-	fi
-
-	[ -e "${S}/.config" ] && make -C ${S} mrproper
 }
 
 # Generate Rockchip style loader binaries
@@ -55,21 +47,17 @@ UBOOT_BINARY = "uboot.img"
 do_compile_append() {
 	cd ${B}
 
-	if [ -e "${B}/${UBOOT_BINARY}" ]; then
-		bbnote "${PN}: Using prebuilt images."
-	else
-		# Prepare needed files
-		for d in make.sh scripts configs arch/arm/mach-rockchip; do
-			cp -rT ${S}/${d} ${d}
-		done
+	# Prepare needed files
+	for d in make.sh scripts configs arch/arm/mach-rockchip; do
+		cp -rT ${S}/${d} ${d}
+	done
 
-		# Remove unneeded stages from make.sh
-		sed -i -e "/^select_tool/d" -e "/^clean/d" -e "/^\t*make/d" \
-			make.sh
+	# Remove unneeded stages from make.sh
+	sed -i -e "/^select_tool/d" -e "/^clean/d" -e "/^\t*make/d" \
+		make.sh
 
-		# Pack rockchip loader images
-		./make.sh ${UBOOT_MACHINE%_defconfig}
-	fi
+	# Pack rockchip loader images
+	./make.sh ${UBOOT_MACHINE%_defconfig}
 
 	ln -sf *_loader*.bin "${RK_LOADER_BIN}"
 


### PR DESCRIPTION
To create / pack Rockchip U-Boot Images (using `make.sh`) it might be better to use generated U-Boot `.config` file instead of using `UBOOT_MACHINE` defconfig.
This way fast code changes (e. g. for testing) are possible, without having to clean build every time.